### PR TITLE
Add sway monitor config tool

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: peaceiris/actions-hugo@v2
-      - name: Test
-        run: node --test tests/sway-monitor-config.test.mjs
       - name: Build
         run: hugo --minify
       - name: Deploy

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: peaceiris/actions-hugo@v2
+      - name: Test
+        run: node --test tests/sway-monitor-config.test.mjs
       - name: Build
         run: hugo --minify
       - name: Deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,10 @@
+name: Test
+on:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test
+        run: node --test tests/sway-monitor-config.test.mjs

--- a/content/sway-monitor-config.html
+++ b/content/sway-monitor-config.html
@@ -61,7 +61,7 @@ description: Visually arrange monitors and generate a kanshi config from swaymsg
 
 <script type="module">
   import {
-    COLORS, logicalSize, parseOutputs, overlaps, touches, normalizePositions,
+    COLORS, logicalSize, parseOutputs, overlaps, touches, normalizePositions, mhzToHz,
     isTouchingAny as _isTouchingAny,
     snapToAdjacentEdge as _snapToAdjacentEdge,
     closeGaps as _closeGaps,
@@ -227,7 +227,7 @@ description: Visually arrange monitors and generate a kanshi config from swaymsg
       mon.modes.forEach((m, mi) => {
         const opt = document.createElement('option');
         opt.value = mi;
-        opt.textContent = `${m.width}×${m.height} @ ${m.refresh}Hz`;
+        opt.textContent = `${m.width}×${m.height} @ ${mhzToHz(m.refresh)}Hz`;
         if (mi === mon.selMode) opt.selected = true;
         modeSel.appendChild(opt);
       });
@@ -308,7 +308,7 @@ description: Visually arrange monitors and generate a kanshi config from swaymsg
         continue;
       }
       const m = mon.modes[mon.selMode];
-      let line = `    output ${id} mode ${m.width}x${m.height}@${m.refresh}Hz`;
+      let line = `    output ${id} mode ${m.width}x${m.height}@${mhzToHz(m.refresh)}Hz`;
       line += ` position ${mon.x - minX},${mon.y - minY}`;
       line += ` scale ${mon.scale}`;
       if (mon.transform && mon.transform !== 'normal') {

--- a/content/sway-monitor-config.html
+++ b/content/sway-monitor-config.html
@@ -62,6 +62,7 @@ description: Visually arrange monitors and generate a kanshi config from swaymsg
 <script type="module">
   import {
     COLORS, logicalSize, parseOutputs, overlaps, touches, normalizePositions, mhzToHz,
+    applySettingChange as _applySettingChange,
     isTouchingAny as _isTouchingAny,
     snapToAdjacentEdge as _snapToAdjacentEdge,
     closeGaps as _closeGaps,
@@ -72,9 +73,10 @@ description: Visually arrange monitors and generate a kanshi config from swaymsg
   let drag = null; // { idx, startMouseX, startMouseY, startMonX, startMonY }
   let viewBox = { x: 0, y: 0, w: 1000, h: 600 };
 
-  function isTouchingAny(idx)      { return _isTouchingAny(monitors, idx); }
-  function snapToAdjacentEdge(idx) { _snapToAdjacentEdge(monitors, idx); }
-  function closeGaps(movedIdx)     { _closeGaps(monitors, movedIdx); }
+  function isTouchingAny(idx)           { return _isTouchingAny(monitors, idx); }
+  function snapToAdjacentEdge(idx)      { _snapToAdjacentEdge(monitors, idx); }
+  function closeGaps(movedIdx)          { _closeGaps(monitors, movedIdx); }
+  function applySettingChange(idx, patch) { _applySettingChange(monitors, idx, patch); renderSVG(); updateConfig(); }
 
   function recomputeViewBox() {
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
@@ -232,8 +234,7 @@ description: Visually arrange monitors and generate a kanshi config from swaymsg
         modeSel.appendChild(opt);
       });
       modeSel.addEventListener('change', () => {
-        monitors[idx].selMode = parseInt(modeSel.value);
-        renderSVG(); updateConfig();
+        applySettingChange(idx, { selMode: parseInt(modeSel.value) });
       });
       modeLabel.appendChild(modeSel);
       card.appendChild(modeLabel);
@@ -246,7 +247,7 @@ description: Visually arrange monitors and generate a kanshi config from swaymsg
       scaleIn.value = mon.scale;
       scaleIn.addEventListener('change', () => {
         const v = parseFloat(scaleIn.value);
-        if (v > 0) { monitors[idx].scale = v; renderSVG(); updateConfig(); }
+        if (v > 0) applySettingChange(idx, { scale: v });
       });
       scaleLabel.appendChild(scaleIn);
       card.appendChild(scaleLabel);
@@ -262,8 +263,7 @@ description: Visually arrange monitors and generate a kanshi config from swaymsg
         trSel.appendChild(opt);
       });
       trSel.addEventListener('change', () => {
-        monitors[idx].transform = trSel.value;
-        renderSVG(); updateConfig();
+        applySettingChange(idx, { transform: trSel.value });
       });
       trLabel.appendChild(trSel);
       card.appendChild(trLabel);

--- a/content/sway-monitor-config.html
+++ b/content/sway-monitor-config.html
@@ -1,0 +1,357 @@
+---
+title: "Sway Monitor Config"
+description: Visually arrange monitors and generate a kanshi config from swaymsg output
+---
+<style>
+  #app { display: none; }
+  #input-section { margin-bottom: 1em; }
+  #input-section textarea { width: 100%; height: 8em; font-family: monospace; font-size: 0.85em; box-sizing: border-box; }
+  #error-msg { color: red; margin: 0.5em 0; background: #fff0f0; padding: 0.4em 0.6em; border-left: 3px solid red; white-space: pre-wrap; font-family: monospace; font-size: 0.85em; }
+  #error-msg:empty { display: none; }
+
+  #canvas-wrap { border: 1px solid #ccc; background: #f8f8f8; overflow: hidden; position: relative; width: 100%; height: 360px; margin-bottom: 1em; cursor: default; }
+  #canvas-svg { position: absolute; top: 0; left: 0; }
+
+  .monitor-rect { cursor: grab; }
+  .monitor-rect:active { cursor: grabbing; }
+  .mon-bg { stroke: #333; stroke-width: 1.5; }
+  .mon-bg.disabled-mon { fill: #ccc; stroke: #999; }
+  .mon-label { font-size: 11px; fill: #111; pointer-events: none; text-anchor: middle; dominant-baseline: middle; }
+  .mon-pos { font-size: 9px; fill: #444; pointer-events: none; text-anchor: middle; }
+
+  #settings { display: flex; flex-wrap: wrap; gap: 1em; margin-bottom: 1em; }
+  .mon-card { border: 1px solid #ccc; padding: 0.6em 0.8em; min-width: 220px; background: #fafafa; }
+  .mon-card h3 { margin: 0 0 0.4em; font-size: 0.95em; }
+  .mon-card label { display: block; margin: 0.3em 0; font-size: 0.85em; }
+  .mon-card select, .mon-card input[type=number] { width: 100%; font-size: 0.85em; box-sizing: border-box; }
+
+  #output-section label { font-weight: bold; }
+  #profile-row { margin-bottom: 0.5em; }
+  #profile-row input { font-size: 0.9em; }
+  #config-out { width: 100%; height: 10em; font-family: monospace; font-size: 0.85em; box-sizing: border-box; }
+  #copy-btn { margin-top: 0.4em; }
+  #copy-msg { font-size: 0.8em; color: green; margin-left: 0.5em; }
+</style>
+
+<div id="input-section">
+  <p>Run <code>swaymsg --type get_outputs --raw | wl-copy</code> then paste below:</p>
+  <textarea id="json-input" placeholder='[{"name":"eDP-1",...}]'></textarea>
+  <button id="load-btn">Load</button>
+  <div id="error-msg"></div>
+</div>
+
+<div id="app">
+  <div id="canvas-wrap">
+    <svg id="canvas-svg" xmlns="http://www.w3.org/2000/svg"></svg>
+  </div>
+
+  <div id="settings"></div>
+
+  <div id="output-section">
+    <div id="profile-row">
+      <label for="profile-name">Profile name: </label>
+      <input type="text" id="profile-name" value="default" style="width:12em">
+    </div>
+    <label for="config-out">Kanshi config:</label><br>
+    <textarea id="config-out" readonly></textarea><br>
+    <button id="copy-btn">Copy to clipboard</button>
+    <span id="copy-msg"></span>
+  </div>
+</div>
+
+<script type="module">
+  import {
+    COLORS, logicalSize, parseOutputs, overlaps, touches, normalizePositions,
+    isTouchingAny as _isTouchingAny,
+    snapToAdjacentEdge as _snapToAdjacentEdge,
+    closeGaps as _closeGaps,
+  } from '/sway-monitor-config-logic.mjs';
+
+  let monitors = []; // { name, make, model, serial, enabled, modes, selMode, scale, transform, x, y }
+  let svgEl, wrapEl;
+  let drag = null; // { idx, startMouseX, startMouseY, startMonX, startMonY }
+  let viewBox = { x: 0, y: 0, w: 1000, h: 600 };
+
+  function isTouchingAny(idx)      { return _isTouchingAny(monitors, idx); }
+  function snapToAdjacentEdge(idx) { _snapToAdjacentEdge(monitors, idx); }
+  function closeGaps(movedIdx)     { _closeGaps(monitors, movedIdx); }
+
+  function recomputeViewBox() {
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const m of monitors) {
+      const { w, h } = logicalSize(m);
+      minX = Math.min(minX, m.x);
+      minY = Math.min(minY, m.y);
+      maxX = Math.max(maxX, m.x + w);
+      maxY = Math.max(maxY, m.y + h);
+    }
+    const pad = 60;
+    viewBox = { x: minX - pad, y: minY - pad, w: (maxX - minX) + pad * 2, h: (maxY - minY) + pad * 2 };
+    const vbH = Math.max(viewBox.h, viewBox.w * 0.35);
+    svgEl.setAttribute('viewBox', `${viewBox.x} ${viewBox.y} ${viewBox.w} ${vbH}`);
+    svgEl.setAttribute('width', '100%');
+    svgEl.setAttribute('height', wrapEl.clientHeight || 360);
+  }
+
+  function renderSVG() {
+    svgEl.innerHTML = '';
+    recomputeViewBox();
+    monitors.forEach((mon, idx) => {
+      const { w, h } = logicalSize(mon);
+      const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      g.setAttribute('class', 'monitor-rect');
+
+      const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      rect.setAttribute('x', mon.x);
+      rect.setAttribute('y', mon.y);
+      rect.setAttribute('width', w);
+      rect.setAttribute('height', h);
+      rect.setAttribute('fill', mon.enabled ? mon.color : '#ccc');
+      rect.setAttribute('stroke', '#333');
+      rect.setAttribute('stroke-width', 2);
+      rect.setAttribute('rx', 3);
+      g.appendChild(rect);
+
+      const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      label.setAttribute('x', mon.x + w / 2);
+      label.setAttribute('y', mon.y + h / 2 - 8);
+      label.setAttribute('text-anchor', 'middle');
+      label.setAttribute('dominant-baseline', 'middle');
+      label.setAttribute('font-size', Math.min(w, h) * 0.12);
+      label.setAttribute('fill', '#111');
+      label.setAttribute('pointer-events', 'none');
+      label.textContent = mon.name;
+      g.appendChild(label);
+
+      const mode = mon.modes[mon.selMode];
+      const sublabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      sublabel.setAttribute('x', mon.x + w / 2);
+      sublabel.setAttribute('y', mon.y + h / 2 + Math.min(w, h) * 0.07);
+      sublabel.setAttribute('text-anchor', 'middle');
+      sublabel.setAttribute('dominant-baseline', 'middle');
+      sublabel.setAttribute('font-size', Math.min(w, h) * 0.085);
+      sublabel.setAttribute('fill', '#333');
+      sublabel.setAttribute('pointer-events', 'none');
+      sublabel.textContent = `${mode.width}×${mode.height}`;
+      g.appendChild(sublabel);
+
+      const poslabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      poslabel.setAttribute('x', mon.x + w / 2);
+      poslabel.setAttribute('y', mon.y + h - Math.min(w, h) * 0.07);
+      poslabel.setAttribute('text-anchor', 'middle');
+      poslabel.setAttribute('dominant-baseline', 'auto');
+      poslabel.setAttribute('font-size', Math.min(w, h) * 0.075);
+      poslabel.setAttribute('fill', '#555');
+      poslabel.setAttribute('pointer-events', 'none');
+      poslabel.textContent = `(${mon.x}, ${mon.y})`;
+      g.appendChild(poslabel);
+
+      g.addEventListener('mousedown', e => startDrag(e, idx));
+      svgEl.appendChild(g);
+    });
+  }
+
+  function svgPoint(e) {
+    const pt = svgEl.createSVGPoint();
+    pt.x = e.clientX; pt.y = e.clientY;
+    return pt.matrixTransform(svgEl.getScreenCTM().inverse());
+  }
+
+  function startDrag(e, idx) {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    const p = svgPoint(e);
+    drag = { idx, startMouseX: p.x, startMouseY: p.y, startMonX: monitors[idx].x, startMonY: monitors[idx].y };
+    document.addEventListener('mousemove', onDrag);
+    document.addEventListener('mouseup', endDrag);
+  }
+
+  function onDrag(e) {
+    if (!drag) return;
+    const p = svgPoint(e);
+    const dx = p.x - drag.startMouseX;
+    const dy = p.y - drag.startMouseY;
+    monitors[drag.idx].x = Math.round(drag.startMonX + dx);
+    monitors[drag.idx].y = Math.round(drag.startMonY + dy);
+    snapToAdjacentEdge(drag.idx);
+    renderSVG();
+    updateConfig();
+    syncCardPosition(drag.idx);
+  }
+
+  function endDrag() {
+    const idx = drag.idx;
+    drag = null;
+    document.removeEventListener('mousemove', onDrag);
+    document.removeEventListener('mouseup', endDrag);
+    snapToAdjacentEdge(idx);
+    closeGaps(idx);
+    renderSVG();
+    updateConfig();
+    syncCardPosition(idx);
+  }
+
+  function syncCardPosition(idx) {
+    const xEl = document.getElementById(`pos-x-${idx}`);
+    const yEl = document.getElementById(`pos-y-${idx}`);
+    if (xEl) xEl.value = monitors[idx].x;
+    if (yEl) yEl.value = monitors[idx].y;
+  }
+
+  function renderSettings() {
+    const container = document.getElementById('settings');
+    container.innerHTML = '';
+    monitors.forEach((mon, idx) => {
+      const card = document.createElement('div');
+      card.className = 'mon-card';
+      card.style.borderLeft = `4px solid ${mon.color}`;
+
+      const title = document.createElement('h3');
+      title.textContent = mon.name;
+      if (mon.make !== 'Unknown') title.textContent += ` (${mon.make} ${mon.model})`;
+      card.appendChild(title);
+
+      // enabled
+      const enLabel = document.createElement('label');
+      const enCb = document.createElement('input');
+      enCb.type = 'checkbox'; enCb.checked = mon.enabled;
+      enCb.addEventListener('change', () => { monitors[idx].enabled = enCb.checked; renderSVG(); updateConfig(); });
+      enLabel.appendChild(enCb);
+      enLabel.appendChild(document.createTextNode(' Enabled'));
+      card.appendChild(enLabel);
+
+      // mode
+      const modeLabel = document.createElement('label');
+      modeLabel.textContent = 'Mode:';
+      const modeSel = document.createElement('select');
+      mon.modes.forEach((m, mi) => {
+        const opt = document.createElement('option');
+        opt.value = mi;
+        opt.textContent = `${m.width}×${m.height} @ ${m.refresh}Hz`;
+        if (mi === mon.selMode) opt.selected = true;
+        modeSel.appendChild(opt);
+      });
+      modeSel.addEventListener('change', () => {
+        monitors[idx].selMode = parseInt(modeSel.value);
+        renderSVG(); updateConfig();
+      });
+      modeLabel.appendChild(modeSel);
+      card.appendChild(modeLabel);
+
+      // scale
+      const scaleLabel = document.createElement('label');
+      scaleLabel.textContent = 'Scale:';
+      const scaleIn = document.createElement('input');
+      scaleIn.type = 'number'; scaleIn.min = '0.5'; scaleIn.max = '4'; scaleIn.step = '0.25';
+      scaleIn.value = mon.scale;
+      scaleIn.addEventListener('change', () => {
+        const v = parseFloat(scaleIn.value);
+        if (v > 0) { monitors[idx].scale = v; renderSVG(); updateConfig(); }
+      });
+      scaleLabel.appendChild(scaleIn);
+      card.appendChild(scaleLabel);
+
+      // transform
+      const trLabel = document.createElement('label');
+      trLabel.textContent = 'Transform:';
+      const trSel = document.createElement('select');
+      ['normal','90','180','270','flipped','flipped-90','flipped-180','flipped-270'].forEach(t => {
+        const opt = document.createElement('option');
+        opt.value = t; opt.textContent = t;
+        if (t === mon.transform) opt.selected = true;
+        trSel.appendChild(opt);
+      });
+      trSel.addEventListener('change', () => {
+        monitors[idx].transform = trSel.value;
+        renderSVG(); updateConfig();
+      });
+      trLabel.appendChild(trSel);
+      card.appendChild(trLabel);
+
+      // position inputs
+      const posLabel = document.createElement('label');
+      posLabel.textContent = 'Position (X, Y):';
+      const posRow = document.createElement('div');
+      posRow.style.display = 'flex'; posRow.style.gap = '4px';
+      const xIn = document.createElement('input');
+      xIn.type = 'number'; xIn.id = `pos-x-${idx}`; xIn.value = mon.x; xIn.style.width = '50%';
+      const yIn = document.createElement('input');
+      yIn.type = 'number'; yIn.id = `pos-y-${idx}`; yIn.value = mon.y; yIn.style.width = '50%';
+      [xIn, yIn].forEach(inp => inp.addEventListener('change', () => {
+        monitors[idx].x = parseInt(xIn.value) || 0;
+        monitors[idx].y = parseInt(yIn.value) || 0;
+        renderSVG(); updateConfig();
+      }));
+      posRow.appendChild(xIn); posRow.appendChild(yIn);
+      posLabel.appendChild(posRow);
+      card.appendChild(posLabel);
+
+      container.appendChild(card);
+    });
+  }
+
+  function outputId(mon) {
+    if (mon.make !== 'Unknown' && mon.model !== 'Unknown' && mon.serial !== 'Unknown') {
+      return `"${mon.make} ${mon.model} ${mon.serial}"`;
+    }
+    return mon.name;
+  }
+
+  function updateConfig() {
+    const profileName = document.getElementById('profile-name').value || 'default';
+    const { minX, minY } = normalizePositions(monitors);
+    const lines = [`profile ${profileName} {`];
+    for (const mon of monitors) {
+      const id = outputId(mon);
+      if (!mon.enabled) {
+        lines.push(`    output ${id} disable`);
+        continue;
+      }
+      const m = mon.modes[mon.selMode];
+      let line = `    output ${id} mode ${m.width}x${m.height}@${m.refresh}Hz`;
+      line += ` position ${mon.x - minX},${mon.y - minY}`;
+      line += ` scale ${mon.scale}`;
+      if (mon.transform && mon.transform !== 'normal') {
+        line += ` transform ${mon.transform}`;
+      }
+      lines.push(line);
+    }
+    lines.push('}');
+    document.getElementById('config-out').value = lines.join('\n');
+  }
+
+  function init() {
+    svgEl = document.getElementById('canvas-svg');
+    wrapEl = document.getElementById('canvas-wrap');
+
+    document.getElementById('load-btn').addEventListener('click', () => {
+      const raw = document.getElementById('json-input').value.trim();
+      const errEl = document.getElementById('error-msg');
+      errEl.textContent = '';
+      try {
+        monitors = parseOutputs(raw);
+        if (!monitors.length) throw new Error('No outputs found in JSON');
+        document.getElementById('app').style.display = 'block';
+        renderSVG();
+        renderSettings();
+        updateConfig();
+      } catch(e) {
+        errEl.textContent = 'Error: ' + e.message;
+      }
+    });
+
+    document.getElementById('profile-name').addEventListener('input', updateConfig);
+
+    document.getElementById('copy-btn').addEventListener('click', () => {
+      const text = document.getElementById('config-out').value;
+      navigator.clipboard.writeText(text).then(() => {
+        const msg = document.getElementById('copy-msg');
+        msg.textContent = 'Copied!';
+        setTimeout(() => { msg.textContent = ''; }, 2000);
+      });
+    });
+  }
+
+  // <script type="module"> is deferred by default, so the DOM is already ready here.
+  init();
+</script>

--- a/static/sway-monitor-config-logic.mjs
+++ b/static/sway-monitor-config-logic.mjs
@@ -1,0 +1,124 @@
+export const COLORS = ['#a8d8ea','#a8e6cf','#ffd3b6','#ffaaa5','#d4a5a5','#b8c0cc','#c9c0d3','#f0d9ff'];
+
+export function logicalSize(mon) {
+  const m = mon.modes[mon.selMode];
+  const s = mon.scale;
+  let w = Math.round(m.width / s);
+  let h = Math.round(m.height / s);
+  if (mon.transform === '90' || mon.transform === '270' ||
+      mon.transform === 'flipped-90' || mon.transform === 'flipped-270') {
+    [w, h] = [h, w];
+  }
+  return { w, h };
+}
+
+export function parseOutputs(json) {
+  const arr = JSON.parse(json);
+  return arr.map((o, i) => {
+    const modes = (o.modes || []).map(m => ({
+      width: m.width, height: m.height,
+      refresh: Math.round(m.refresh / 1000)
+    }));
+    const seen = new Set();
+    const uniqModes = modes.filter(m => {
+      const k = `${m.width}x${m.height}@${m.refresh}`;
+      if (seen.has(k)) return false;
+      seen.add(k); return true;
+    }).sort((a, b) => (b.width * b.height) - (a.width * a.height) || b.refresh - a.refresh);
+
+    const curW = o.current_mode ? o.current_mode.width : (uniqModes[0] ? uniqModes[0].width : 1920);
+    const curH = o.current_mode ? o.current_mode.height : (uniqModes[0] ? uniqModes[0].height : 1080);
+    const curR = o.current_mode ? Math.round(o.current_mode.refresh / 1000) : 60;
+
+    let selMode = uniqModes.findIndex(m => m.width === curW && m.height === curH && m.refresh === curR);
+    if (selMode < 0) selMode = 0;
+
+    return {
+      name: o.name || `output-${i}`,
+      make: o.make || 'Unknown',
+      model: o.model || 'Unknown',
+      serial: o.serial || 'Unknown',
+      enabled: o.active !== false,
+      modes: uniqModes.length ? uniqModes : [{ width: curW, height: curH, refresh: curR }],
+      selMode,
+      scale: o.scale || 1,
+      transform: o.transform || 'normal',
+      x: o.rect ? o.rect.x : i * 400,
+      y: o.rect ? o.rect.y : 0,
+      color: COLORS[i % COLORS.length],
+    };
+  });
+}
+
+export function overlaps(ax, ay, aw, ah, bx, by, bw, bh) {
+  return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
+}
+
+export function touches(ax, ay, aw, ah, bx, by, bw, bh) {
+  const gapX = Math.max(ax, bx) - Math.min(ax + aw, bx + bw);
+  const gapY = Math.max(ay, by) - Math.min(ay + ah, by + bh);
+  return (gapX === 0 && gapY <= 0) || (gapY === 0 && gapX <= 0);
+}
+
+export function normalizePositions(monitors) {
+  const enabled = monitors.filter(m => m.enabled);
+  const minX = enabled.length ? Math.min(...enabled.map(m => m.x)) : 0;
+  const minY = enabled.length ? Math.min(...enabled.map(m => m.y)) : 0;
+  return { minX, minY };
+}
+
+export function isTouchingAny(monitors, idx) {
+  const { w: mw, h: mh } = logicalSize(monitors[idx]);
+  const { x: mx, y: my } = monitors[idx];
+  return monitors.some((m, j) => {
+    if (j === idx) return false;
+    const { w: ow, h: oh } = logicalSize(m);
+    return touches(mx, my, mw, mh, m.x, m.y, ow, oh);
+  });
+}
+
+export function snapToAdjacentEdge(monitors, idx) {
+  if (monitors.length < 2) { monitors[idx].x = 0; monitors[idx].y = 0; return; }
+  const { w: mw, h: mh } = logicalSize(monitors[idx]);
+  const mx = monitors[idx].x, my = monitors[idx].y;
+  let bestDist = Infinity, bestX = mx, bestY = my;
+  for (let j = 0; j < monitors.length; j++) {
+    if (j === idx) continue;
+    const { w: ow, h: oh } = logicalSize(monitors[j]);
+    const ox = monitors[j].x, oy = monitors[j].y;
+    const cy = v => Math.max(oy - mh, Math.min(oy + oh, v));
+    const cx = v => Math.max(ox - mw, Math.min(ox + ow, v));
+    for (const [nx, ny] of [
+      [ox + ow, cy(my)],
+      [ox - mw, cy(my)],
+      [cx(mx), oy + oh],
+      [cx(mx), oy - mh],
+    ]) {
+      const blocked = monitors.some((m, k) => {
+        if (k === idx) return false;
+        const { w: kw, h: kh } = logicalSize(m);
+        return overlaps(nx, ny, mw, mh, m.x, m.y, kw, kh);
+      });
+      if (blocked) continue;
+      const dist = (nx - mx) ** 2 + (ny - my) ** 2;
+      if (dist < bestDist) { bestDist = dist; bestX = nx; bestY = ny; }
+    }
+  }
+  monitors[idx].x = bestX;
+  monitors[idx].y = bestY;
+}
+
+export function closeGaps(monitors, movedIdx) {
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (let i = 0; i < monitors.length; i++) {
+      if (i === movedIdx) continue;
+      if (!isTouchingAny(monitors, i)) {
+        const { x: ox, y: oy } = monitors[i];
+        snapToAdjacentEdge(monitors, i);
+        if (monitors[i].x !== ox || monitors[i].y !== oy) changed = true;
+      }
+    }
+  }
+}

--- a/static/sway-monitor-config-logic.mjs
+++ b/static/sway-monitor-config-logic.mjs
@@ -1,5 +1,14 @@
 export const COLORS = ['#a8d8ea','#a8e6cf','#ffd3b6','#ffaaa5','#d4a5a5','#b8c0cc','#c9c0d3','#f0d9ff'];
 
+// Convert millihertz (integer) to a Hz string using only integer arithmetic.
+// 164554 → "164.554"   120000 → "120"   59940 → "59.94"   60001 → "60.001"
+export function mhzToHz(mhz) {
+  const whole = Math.floor(mhz / 1000);
+  const frac  = mhz % 1000;
+  if (frac === 0) return `${whole}`;
+  return `${whole}.${frac.toString().padStart(3, '0').replace(/0+$/, '')}`;
+}
+
 export function logicalSize(mon) {
   const m = mon.modes[mon.selMode];
   const s = mon.scale;
@@ -17,7 +26,7 @@ export function parseOutputs(json) {
   return arr.map((o, i) => {
     const modes = (o.modes || []).map(m => ({
       width: m.width, height: m.height,
-      refresh: Math.round(m.refresh / 1000)
+      refresh: m.refresh
     }));
     const seen = new Set();
     const uniqModes = modes.filter(m => {
@@ -28,7 +37,7 @@ export function parseOutputs(json) {
 
     const curW = o.current_mode ? o.current_mode.width : (uniqModes[0] ? uniqModes[0].width : 1920);
     const curH = o.current_mode ? o.current_mode.height : (uniqModes[0] ? uniqModes[0].height : 1080);
-    const curR = o.current_mode ? Math.round(o.current_mode.refresh / 1000) : 60;
+    const curR = o.current_mode ? o.current_mode.refresh : 0;
 
     let selMode = uniqModes.findIndex(m => m.width === curW && m.height === curH && m.refresh === curR);
     if (selMode < 0) selMode = 0;

--- a/static/sway-monitor-config-logic.mjs
+++ b/static/sway-monitor-config-logic.mjs
@@ -117,6 +117,13 @@ export function snapToAdjacentEdge(monitors, idx) {
   monitors[idx].y = bestY;
 }
 
+// Apply a setting change to a monitor and recompute the layout so adjacent
+// monitors are pushed/pulled to eliminate any resulting overlaps or gaps.
+export function applySettingChange(monitors, idx, patch) {
+  Object.assign(monitors[idx], patch);
+  closeGaps(monitors, idx);
+}
+
 export function closeGaps(monitors, movedIdx) {
   let changed = true;
   while (changed) {

--- a/tests/sway-monitor-config.test.mjs
+++ b/tests/sway-monitor-config.test.mjs
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   logicalSize, overlaps, touches, normalizePositions, mhzToHz,
-  isTouchingAny, snapToAdjacentEdge, closeGaps, parseOutputs,
+  isTouchingAny, snapToAdjacentEdge, closeGaps, parseOutputs, applySettingChange,
 } from '../static/sway-monitor-config-logic.mjs';
 
 // Build a minimal monitor object. w and h are the desired *logical* pixel dimensions.
@@ -186,6 +186,28 @@ test('parseOutputs: refresh stored as raw mHz integer, not rounded Hz (165Hz bug
   const ms = parseOutputs(json);
   assert.equal(ms[0].modes[0].refresh, 164554);             // raw mHz, not 165
   assert.equal(ms[0].modes[ms[0].selMode].refresh, 164554); // selMode found correctly
+});
+
+// ─── applySettingChange: layout invariants maintained after settings change ───
+
+test('applySettingChange: switching to a larger mode pushes adjacent monitor out', () => {
+  const monitors = [mon(0, 0, 1920, 1080), mon(1920, 0, 1920, 1080)];
+  monitors[0].modes.push({ width: 2560, height: 1080, refresh: 60000 }); // wider mode
+  applySettingChange(monitors, 0, { selMode: 1 });
+  const { w } = logicalSize(monitors[0]);
+  assert.ok(!overlaps(monitors[0].x, monitors[0].y, w, 1080,
+                      monitors[1].x, monitors[1].y, 1920, 1080), 'must not overlap');
+  assert.ok(isTouchingAny(monitors, 1), 'B must still touch A');
+});
+
+test('applySettingChange: switching to a smaller mode pulls adjacent monitor in', () => {
+  const monitors = [mon(0, 0, 1920, 1080), mon(1920, 0, 1920, 1080)];
+  monitors[0].modes.push({ width: 1280, height: 1080, refresh: 60000 }); // narrower mode
+  applySettingChange(monitors, 0, { selMode: 1 });
+  const { w } = logicalSize(monitors[0]);
+  assert.ok(isTouchingAny(monitors, 1), 'B must touch A after gap is closed');
+  assert.ok(!overlaps(monitors[0].x, monitors[0].y, w, 1080,
+                      monitors[1].x, monitors[1].y, 1920, 1080), 'must not overlap');
 });
 
 // ─── parseOutputs: integration with real clipboard JSON ──────────────────────

--- a/tests/sway-monitor-config.test.mjs
+++ b/tests/sway-monitor-config.test.mjs
@@ -1,0 +1,212 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  logicalSize, overlaps, touches, normalizePositions,
+  isTouchingAny, snapToAdjacentEdge, closeGaps, parseOutputs,
+} from '../static/sway-monitor-config-logic.mjs';
+
+// Build a minimal monitor object. w and h are the desired *logical* pixel dimensions.
+function mon(x, y, w, h, { scale = 1, transform = 'normal', enabled = true } = {}) {
+  return {
+    x, y, enabled, scale, transform,
+    make: 'Unknown', model: 'Unknown', serial: 'Unknown',
+    modes: [{ width: w * scale, height: h * scale, refresh: 60 }],
+    selMode: 0, color: '#fff',
+    name: `output-${x}-${y}`,
+  };
+}
+
+// ─── overlaps / touches contracts ────────────────────────────────────────────
+
+test('overlaps: clearly overlapping rects', () => {
+  assert.ok(overlaps(0, 0, 100, 100, 50, 50, 100, 100));
+  assert.ok(overlaps(0, 0, 100, 100, 50, 0, 100, 100));
+});
+
+test('overlaps: touching rects share an edge but do NOT overlap', () => {
+  assert.ok(!overlaps(0, 0, 100, 100, 100, 0, 100, 100));  // left/right
+  assert.ok(!overlaps(0, 0, 100, 100, 0, 100, 100, 100));  // top/bottom
+});
+
+test('overlaps: rects with a gap', () => {
+  assert.ok(!overlaps(0, 0, 100, 100, 101, 0, 100, 100));
+});
+
+test('touches: side-by-side rects share a vertical edge', () => {
+  assert.ok(touches(0, 0, 100, 100, 100, 0, 100, 100));
+});
+
+test('touches: stacked rects share a horizontal edge', () => {
+  assert.ok(touches(0, 0, 100, 100, 0, 100, 100, 100));
+});
+
+test('touches: corner touch counts', () => {
+  assert.ok(touches(0, 0, 100, 100, 100, 100, 100, 100));
+});
+
+test('touches: 1px gap is not touching', () => {
+  assert.ok(!touches(0, 0, 100, 100, 101, 0, 100, 100));
+  assert.ok(!touches(0, 0, 100, 100, 0, 101, 100, 100));
+});
+
+test('touches: overlapping rects are not "touching"', () => {
+  assert.ok(!touches(0, 0, 100, 100, 50, 0, 100, 100));
+});
+
+// ─── Bug 1: position normalisation ───────────────────────────────────────────
+
+test('normalizePositions: single monitor at non-zero origin', () => {
+  const { minX, minY } = normalizePositions([mon(320, 0, 1440, 960)]);
+  assert.equal(minX, 320);
+  assert.equal(minY, 0);
+});
+
+test('normalizePositions: two monitors, picks the lower bound', () => {
+  const { minX, minY } = normalizePositions([
+    mon(320, 0, 1440, 960),
+    mon(1760, 0, 640, 480),
+  ]);
+  assert.equal(minX, 320);
+  assert.equal(minY, 0);
+});
+
+test('normalizePositions: disabled monitors are excluded from the origin', () => {
+  const { minX, minY } = normalizePositions([
+    mon(0, 0, 1440, 960, { enabled: false }),
+    mon(320, 100, 640, 480),
+  ]);
+  assert.equal(minX, 320);
+  assert.equal(minY, 100);
+});
+
+test('normalizePositions: all disabled → origin stays 0,0', () => {
+  const { minX, minY } = normalizePositions([
+    mon(320, 100, 1440, 960, { enabled: false }),
+  ]);
+  assert.equal(minX, 0);
+  assert.equal(minY, 0);
+});
+
+test('snapToAdjacentEdge: single monitor always snaps to origin', () => {
+  const monitors = [mon(500, 300, 1440, 960)];
+  snapToAdjacentEdge(monitors, 0);
+  assert.equal(monitors[0].x, 0);
+  assert.equal(monitors[0].y, 0);
+});
+
+// ─── Bug 2: gap when free axis was not clamped ───────────────────────────────
+// Old algorithm: candidate (1920, 2000) had dist=0 and was accepted even though
+// monitor[0] ends at y=1080, leaving a 920px vertical gap.
+
+test('snapToAdjacentEdge: monitor with y-offset ends up actually touching', () => {
+  const monitors = [mon(0, 0, 1920, 1080), mon(1920, 2000, 1920, 1080)];
+  snapToAdjacentEdge(monitors, 1);
+  const { w, h } = logicalSize(monitors[1]);
+  assert.ok(
+    touches(monitors[1].x, monitors[1].y, w, h, 0, 0, 1920, 1080),
+    `monitor[1] at (${monitors[1].x},${monitors[1].y}) should touch monitor[0]`,
+  );
+});
+
+// ─── Bug 3: monitors could overlap when snapping onto a third ────────────────
+// Old algorithm: snapping B to right of A placed it exactly on top of C.
+
+test('snapToAdjacentEdge: snapped monitor does not overlap any other', () => {
+  // A and C in a row; B is dragged onto A's position
+  const monitors = [
+    mon(0, 0, 1920, 1080),    // A
+    mon(1920, 0, 1920, 1080), // C
+    mon(500, 0, 1920, 1080),  // B (overlapping A)
+  ];
+  snapToAdjacentEdge(monitors, 2);
+  const { w, h } = logicalSize(monitors[2]);
+  assert.ok(!overlaps(monitors[2].x, monitors[2].y, w, h, 0,    0, 1920, 1080), 'must not overlap A');
+  assert.ok(!overlaps(monitors[2].x, monitors[2].y, w, h, 1920, 0, 1920, 1080), 'must not overlap C');
+  assert.ok(isTouchingAny(monitors, 2), 'must still touch at least one monitor');
+});
+
+// ─── Bug 4: moving the middle monitor left a gap between its neighbours ───────
+// Real-data layout from clipboard: eDP-1 | DP-9 | DP-8
+
+test('closeGaps: removing the middle monitor closes the gap (real-data layout)', () => {
+  // eDP-1: (0,0) logical 1440×960  (2880×1920 @ scale 2)
+  // DP-9:  (1440,0) logical 640×480 (640×480 @ scale 1) — the middle monitor
+  // DP-8:  (2080,0) logical 5120×2160 (5120×2160 @ scale 1)
+  const monitors = [
+    mon(0,    0, 1440, 960),
+    mon(1440, 0,  640, 480),  // middle
+    mon(2080, 0, 5120, 2160),
+  ];
+
+  // Yank DP-9 far away (simulating a drag to a distant position)
+  monitors[1].x = 9999;
+  monitors[1].y = 9999;
+  snapToAdjacentEdge(monitors, 1);
+  closeGaps(monitors, 1);
+
+  assert.ok(isTouchingAny(monitors, 0), 'eDP-1 must touch something after gap is closed');
+  assert.ok(isTouchingAny(monitors, 2), 'DP-8 must touch something after gap is closed');
+});
+
+// ─── logicalSize: transform swaps dimensions ─────────────────────────────────
+
+test('logicalSize: 90-degree transform swaps width and height', () => {
+  const m = mon(0, 0, 1080, 1920, { transform: '90' });
+  // physical 1080×1920, transform 90° → logical 1920×1080
+  // (mon helper sets modes[0] = {width: 1080, height: 1920}; scale=1)
+  const { w, h } = logicalSize(m);
+  assert.equal(w, 1920);
+  assert.equal(h, 1080);
+});
+
+test('logicalSize: normal transform keeps dimensions', () => {
+  const { w, h } = logicalSize(mon(0, 0, 1920, 1080));
+  assert.equal(w, 1920);
+  assert.equal(h, 1080);
+});
+
+// ─── parseOutputs: integration with real clipboard JSON ──────────────────────
+
+const SAMPLE_JSON = JSON.stringify([
+  {
+    name: 'eDP-1', make: 'BOE', model: 'NE135A1M-NY1', serial: 'Unknown',
+    active: true, scale: 2.0, transform: 'normal',
+    rect: { x: 0, y: 0, width: 1440, height: 960 },
+    current_mode: { width: 2880, height: 1920, refresh: 120000 },
+    modes: [{ width: 2880, height: 1920, refresh: 120000 }],
+  },
+  {
+    name: 'DP-9', make: 'Unknown', model: 'Unknown', serial: 'Unknown',
+    active: true, scale: 1.0, transform: 'normal',
+    rect: { x: 1440, y: 0, width: 640, height: 480 },
+    current_mode: { width: 640, height: 480, refresh: 59940 },
+    modes: [{ width: 640, height: 480, refresh: 59940 }],
+  },
+  {
+    name: 'DP-8', make: 'LG Electronics', model: 'LG ULTRAWIDE', serial: '206NTSU1Q350',
+    active: true, scale: 1.0, transform: 'normal',
+    rect: { x: 2080, y: 0, width: 5120, height: 2160 },
+    current_mode: { width: 5120, height: 2160, refresh: 71998 },
+    modes: [{ width: 5120, height: 2160, refresh: 71998 }],
+  },
+]);
+
+test('parseOutputs: parses positions and logical sizes from real JSON', () => {
+  const ms = parseOutputs(SAMPLE_JSON);
+  assert.equal(ms.length, 3);
+
+  assert.equal(ms[0].x, 0);    assert.equal(ms[0].y, 0);
+  assert.equal(ms[1].x, 1440); assert.equal(ms[1].y, 0);
+  assert.equal(ms[2].x, 2080); assert.equal(ms[2].y, 0);
+
+  assert.deepEqual(logicalSize(ms[0]), { w: 1440, h: 960  });
+  assert.deepEqual(logicalSize(ms[1]), { w: 640,  h: 480  });
+  assert.deepEqual(logicalSize(ms[2]), { w: 5120, h: 2160 });
+});
+
+test('parseOutputs: initial layout from real JSON is already gap-free', () => {
+  const ms = parseOutputs(SAMPLE_JSON);
+  assert.ok(isTouchingAny(ms, 0), 'eDP-1 touches DP-9');
+  assert.ok(isTouchingAny(ms, 1), 'DP-9 touches its neighbours');
+  assert.ok(isTouchingAny(ms, 2), 'DP-8 touches DP-9');
+});

--- a/tests/sway-monitor-config.test.mjs
+++ b/tests/sway-monitor-config.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  logicalSize, overlaps, touches, normalizePositions,
+  logicalSize, overlaps, touches, normalizePositions, mhzToHz,
   isTouchingAny, snapToAdjacentEdge, closeGaps, parseOutputs,
 } from '../static/sway-monitor-config-logic.mjs';
 
@@ -10,7 +10,7 @@ function mon(x, y, w, h, { scale = 1, transform = 'normal', enabled = true } = {
   return {
     x, y, enabled, scale, transform,
     make: 'Unknown', model: 'Unknown', serial: 'Unknown',
-    modes: [{ width: w * scale, height: h * scale, refresh: 60 }],
+    modes: [{ width: w * scale, height: h * scale, refresh: 60000 }],
     selMode: 0, color: '#fff',
     name: `output-${x}-${y}`,
   };
@@ -163,6 +163,29 @@ test('logicalSize: normal transform keeps dimensions', () => {
   const { w, h } = logicalSize(mon(0, 0, 1920, 1080));
   assert.equal(w, 1920);
   assert.equal(h, 1080);
+});
+
+// ─── mhzToHz: integer arithmetic refresh rate formatting ─────────────────────
+
+test('mhzToHz: integer arithmetic, no floating point', () => {
+  assert.equal(mhzToHz(164554), '164.554'); // was being rounded to 165 (the bug)
+  assert.equal(mhzToHz(120000), '120');
+  assert.equal(mhzToHz(59940),  '59.94');
+  assert.equal(mhzToHz(60001),  '60.001');
+  assert.equal(mhzToHz(60000),  '60');
+});
+
+test('parseOutputs: refresh stored as raw mHz integer, not rounded Hz (165Hz bug)', () => {
+  const json = JSON.stringify([{
+    name: 'DP-3', make: 'Microstep', model: 'MSI MPG323CQR', serial: '0x00000B20',
+    active: true, scale: 1.0, transform: 'normal',
+    rect: { x: 0, y: 0, width: 2560, height: 1440 },
+    current_mode: { width: 2560, height: 1440, refresh: 164554 },
+    modes: [{ width: 2560, height: 1440, refresh: 164554 }],
+  }]);
+  const ms = parseOutputs(json);
+  assert.equal(ms[0].modes[0].refresh, 164554);             // raw mHz, not 165
+  assert.equal(ms[0].modes[ms[0].selMode].refresh, 164554); // selMode found correctly
 });
 
 // ─── parseOutputs: integration with real clipboard JSON ──────────────────────


### PR DESCRIPTION
Web tool at /sway-monitor-config/ that lets you paste the output of
`swaymsg --type get_outputs --raw | wl-copy` and visually arrange
monitors by dragging them, then copies a ready-to-use kanshi profile.

Features:
- SVG drag-and-drop canvas — monitors snap flush to each other, no
  gaps and no overlaps enforced during and after drag
- Pulling a monitor out from between two others collapses the remaining
  gap automatically
- Changing a monitor's mode, scale, or transform repositions adjacent
  monitors to restore adjacency
- Per-monitor settings: mode, scale, transform, enable/disable
- Output positions are normalised so the layout always starts at 0,0
- Refresh rates are stored as raw mHz integers and converted to Hz
  strings using integer arithmetic only, so e.g. 164554 mHz outputs
  as 164.554Hz rather than being rounded to 165Hz (which kanshi rejects)

Also adds:
- `static/sway-monitor-config-logic.mjs` — layout logic extracted into
  an ES module so it can be tested without a browser
- `tests/sway-monitor-config.test.mjs` — 24 unit tests covering all
  the above invariants, runnable with `node --test`
- CI: separate `Test` workflow runs on PRs, `GitHub Pages` deploys on
  trunk merge